### PR TITLE
Use a reliable gpg keyserver pool

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -99,7 +99,9 @@ get_java() {
 			-o $destdir/${variant}.sig $signature
 		
 		# gpg servers are known not to be reliable
-		gpg --recv $sigkey || gpg --recv $sigkey || gpg --recv $sigkey
+		gpg --keyserver pool.sks-keyservers.net --recv $sigkey \
+		|| gpg --keyserver pool.sks-keyservers.net --recv $sigkey \
+		|| gpg --keyserver pool.sks-keyservers.net --recv $sigkey
 		if gpg --verify $destdir/${variant}.sig ; then
 			echo "Archive verification: successful"
 		else


### PR DESCRIPTION
The server pool `pool.sks-keyservers.net` appears to work at the first try on every occasion :-)