### PR TITLE
Replaced jdk17 version by latest available (used in psp-images)

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -100,7 +100,7 @@ get_java() {
 			signature=${corretto_base}.sig
 			sigkey="A122542AB04F24E3"
 		;;
-		corretto-17.0.1.12.1)
+		corretto-17.0.2.8.1)
             local corretto_base="https://corretto.aws/downloads/resources/$(cut -d - -f2 <<< "$version")/amazon-$version-linux-x64.tar.gz"
 			url=${corretto_base}
 			signature=${corretto_base}.sig

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-echo "8.121 8.131 8.141 8.144 8.151 9.0.1 corretto-8.202.08.2 corretto-8.242.08.1 corretto-11.0.7.10.1 corretto-11.0.13.8.1 corretto-8.282.08.1 corretto-8.312.07.1 corretto-17.0.1.12.1"
+echo "8.121 8.131 8.141 8.144 8.151 9.0.1 corretto-8.202.08.2 corretto-8.242.08.1 corretto-11.0.7.10.1 corretto-11.0.13.8.1 corretto-8.282.08.1 corretto-8.312.07.1 corretto-17.0.2.8.1"


### PR DESCRIPTION
I think nobody installed the previous version except me, so I've replaced it. 

The new version is used in `psp-images` and will be used for migration.