### PR TITLE
Change GPG servers used to check signature

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -134,12 +134,14 @@ get_java() {
 			-o $destdir/${variant}.sig $signature
 
 		# gpg servers are known not to be reliable
-		gpg --keyserver hkp://ha.pool.sks-keyservers.net:80  --recv $sigkey \
-		|| gpg --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv $sigkey \
-		|| gpg --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv $sigkey \
+		gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv $sigkey \
+		|| gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv $sigkey \
 		|| gpg --keyserver hkp://ipv4.pool.sks-keyservers.net:80 --recv $sigkey \
 		|| gpg --keyserver hkp://ipv4.pool.sks-keyservers.net:80 --recv $sigkey \
-		|| gpg --keyserver hkp://ipv4.pool.sks-keyservers.net:80 --recv $sigkey
+		|| gpg --keyserver pgp.mit.edu --recv $sigkey \
+		|| gpg --keyserver pgp.mit.edu --recv $sigkey \
+		|| gpg --keyserver keyserver.pgp.com --recv $sigkey \
+		|| gpg --keyserver keyserver.pgp.com --recv $sigkey
 		if gpg --verify $destdir/${variant}.sig ; then
 			echo "Archive verification: successful"
 		else


### PR DESCRIPTION
Related to Proemion/connect-portal/pull/1352

See an example of an installation failure in [this build](https://jenkins.ad1.proemion.com/blue/rest/organizations/jenkins/pipelines/builds/pipelines/connect-portal/branches/trying/runs/203/nodes/28/steps/62/log/?start=0).

The relevant part is:
```
[2022-06-13T13:13:41.840Z] downloading: https://corretto.aws/downloads/resources/11.0.13.8.1/amazon-corretto-11.0.13.8.1-linux-x64.tar.gz
[2022-06-13T13:13:52.139Z] gpg: directory '/home/ubuntu/.gnupg' created
[2022-06-13T13:13:52.139Z] gpg: keybox '/home/ubuntu/.gnupg/pubring.kbx' created
[2022-06-13T13:14:14.383Z] gpg: keyserver receive failed: Server indicated a failure
[2022-06-13T13:14:32.844Z] gpg: keyserver receive failed: Server indicated a failure
[2022-06-13T13:14:48.068Z] gpg: keyserver receive failed: Server indicated a failure
[2022-06-13T13:14:48.324Z] gpg: keyserver receive failed: Server indicated a failure
[2022-06-13T13:14:48.624Z] gpg: keyserver receive failed: Server indicated a failure
[2022-06-13T13:14:48.624Z] gpg: keyserver receive failed: Server indicated a failure
[2022-06-13T13:14:48.624Z] gpg: assuming signed data in '/home/ubuntu/.asdf/installs/java/corretto-11.0.13.8.1/linux-x64.tar.gz'
[2022-06-13T13:14:50.072Z] gpg: Signature made Wed 13 Oct 2021 09:32:40 PM UTC
[2022-06-13T13:14:50.072Z] gpg:                using RSA key A122542AB04F24E3
[2022-06-13T13:14:50.072Z] gpg: Can't check signature: No public key
```

Unless I'm reading that wrong we are basically importing keys from the servers and failing at that. I've also run locally the install and I got the same failures. After a bit the last one started to work fine but I'm not sure why we should keep around servers that fails. So I've updated the list as per this PR and locally I got no errors any more. See e.g. `Java 17` installation:

```sh
[fb5003@fb5003 connect-portal]$ asdf install java corretto-17.0.2.8.1
---- ASDF JAVA MESSAGE ----
downloading: https://corretto.aws/downloads/resources/17.0.2.8.1/amazon-corretto-17.0.2.8.1-linux-x64.tar.gz
gpg: key A122542AB04F24E3: "Amazon Services LLC (Amazon Corretto release) <corretto-team@amazon.com>" not changed
gpg: Total number processed: 1
gpg:              unchanged: 1
gpg: assuming signed data in '/home/fb5003/.asdf/installs/java/corretto-17.0.2.8.1/linux-x64.tar.gz'
gpg: Signature made lun 17 gen 2022, 05:55:49 CET
gpg:                using RSA key A122542AB04F24E3
gpg: Good signature from "Amazon Services LLC (Amazon Corretto release) <corretto-team@amazon.com>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 6DC3 636D AE53 4049 C8B9  4623 A122 542A B04F 24E3
Archive verification: successful
---- ASDF JAVA MESSAGE ----
expanding java dist
[fb5003@fb5003 connect-portal]$ 
```

Let's use the newer list as that seems more robust. :slightly_smiling_face: 